### PR TITLE
Bugfix for all-day appointments bug

### DIFF
--- a/src/main/java/com/zerodes/exchangesync/calendarsource/google/GoogleCalendarSourceImpl.java
+++ b/src/main/java/com/zerodes/exchangesync/calendarsource/google/GoogleCalendarSourceImpl.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import microsoft.exchange.webservices.data.util.TimeZoneUtils;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/zerodes/exchangesync/dto/AppointmentDto.java
+++ b/src/main/java/com/zerodes/exchangesync/dto/AppointmentDto.java
@@ -134,6 +134,7 @@ public class AppointmentDto {
 		dest.location = location;
 		dest.organizer = organizer;
 		dest.attendees = attendees;
+		dest.allDay = allDay;
 	}
 
 	public enum RecurrenceType {

--- a/src/main/java/com/zerodes/exchangesync/exchange/ExchangeSourceImpl.java
+++ b/src/main/java/com/zerodes/exchangesync/exchange/ExchangeSourceImpl.java
@@ -239,51 +239,6 @@ public class ExchangeSourceImpl implements TaskSource, CalendarSource {
 		return appointmentDto;
 	}
 
-	public AppointmentDto convertToAppointmentDto(final MeetingRequest meeting) throws ServiceLocalException {
-		final AppointmentDto appointmentDto = new AppointmentDto();
-		appointmentDto.setExchangeId(meeting.getId().getUniqueId());
-		appointmentDto.setLastModified(convertToJodaDateTime(meeting.getLastModifiedTime()));
-		appointmentDto.setSummary(meeting.getSubject());
-		try {
-			appointmentDto.setDescription(MessageBody.getStringFromMessageBody(meeting.getBody()));
-		} catch (final Exception e) {
-			LOG.error("Unable to retrieve appointment body from Exchange", e);
-		}
-		appointmentDto.setStart(convertToJodaDateTime(meeting.getStart()));
-		appointmentDto.setEnd(convertToJodaDateTime(meeting.getEnd()));
-		appointmentDto.setAllDay(meeting.getIsAllDayEvent());
-		appointmentDto.setLocation(meeting.getLocation());
-		if (meeting.getOrganizer() != null) {
-			appointmentDto.setOrganizer(convertToPersonDto(meeting.getOrganizer(), false));
-		}
-		final Set<PersonDto> attendees = new HashSet<PersonDto>();
-		if (meeting.getRequiredAttendees() != null) {
-			for (final Attendee exchangeAttendee : meeting.getRequiredAttendees()) {
-				attendees.add(convertToPersonDto(exchangeAttendee, false));
-			}
-		}
-		if (meeting.getOptionalAttendees() != null) {
-			for (final Attendee exchangeAttendee : meeting.getOptionalAttendees()) {
-				attendees.add(convertToPersonDto(exchangeAttendee, true));
-			}
-		}
-		appointmentDto.setAttendees(attendees);
-		appointmentDto.setReminderMinutesBeforeStart(meeting.getReminderMinutesBeforeStart());
-		if (meeting.getRecurrence() != null) {
-			if (meeting.getRecurrence() instanceof Recurrence.DailyPattern) {
-				appointmentDto.setRecurrenceType(RecurrenceType.DAILY);
-			} else if (meeting.getRecurrence() instanceof Recurrence.WeeklyPattern) {
-				appointmentDto.setRecurrenceType(RecurrenceType.WEEKLY);
-			} else if (meeting.getRecurrence() instanceof Recurrence.MonthlyPattern) {
-				appointmentDto.setRecurrenceType(RecurrenceType.MONTHLY);
-			} else if (meeting.getRecurrence() instanceof Recurrence.YearlyPattern) {
-				appointmentDto.setRecurrenceType(RecurrenceType.YEARLY);
-			}
-			appointmentDto.setRecurrenceCount(meeting.getRecurrence().getNumberOfOccurrences());
-		}
-		return appointmentDto;
-	}
-
 	/**
 	 * Convert EWS dates to Joda time DateTime objects.
 	 *


### PR DESCRIPTION
This should solve the bug #21.

The Problem: ```convertToDate``` (with the ```onlyDate=true``` parameter) forgets all information about the time zone and also the time zone is not used for extracting the date in the "target" time zone - so we have to do it manually.